### PR TITLE
Switch to ubuntu 20.04 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM ubuntu:20.04
 MAINTAINER Portworx Inc. <support@portworx.com>
 
 ARG VERSION=master


### PR DESCRIPTION
**What type of PR is this?**
>cleanup


**What this PR does / why we need it**:
As discussed, let's switch to a ubuntu base image. It's way easier to use!

**Does this PR change a user-facing CRD or CLI?**:
N/A

**Is a release note needed?**:

```release-note
Latest Base Image: ubuntu 20.04
```

**Does this change need to be cherry-picked to a release branch?**:
N/A

